### PR TITLE
added zoom-to widget

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,20 +2,10 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="d58156a1-03b5-4318-81ef-90b21f9c6bc5" name="Default" comment="">
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/app/templates/images/wimvectorxs.png" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/.name" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/encodings.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/generator-wim.iml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/libraries/generator_wim_node_modules.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/jsLibraryMappings.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/misc.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/modules.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/scopes/scope_settings.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/vcs.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/app/templates/map-esri/_core.js" afterPath="$PROJECT_DIR$/app/templates/map-esri/_core.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/app/templates/_index.html" afterPath="$PROJECT_DIR$/app/templates/_index.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/app/templates/map-esri/_layers.js" afterPath="$PROJECT_DIR$/app/templates/map-esri/_layers.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/app/templates/_main.css" afterPath="$PROJECT_DIR$/app/templates/_main.css" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
     </list>
     <ignored path="generator-wim.iws" />
     <ignored path=".idea/workspace.xml" />
@@ -40,29 +30,39 @@
         <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_core.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="320" column="11" selection-start-line="320" selection-start-column="11" selection-end-line="320" selection-end-column="11" />
+              <caret line="799" column="35" selection-start-line="799" selection-start-column="35" selection-end-line="799" selection-end-column="35" />
               <folding>
-                <marker date="1446068830007" expanded="true" signature="16644:16678" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="18685:18719" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="19154:19188" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="22019:22035" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="22140:22174" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="22592:22608" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="22706:22740" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="23065:23081" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="23186:23220" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="23430:23446" placeholder="..." />
-                <marker date="1446068830007" expanded="true" signature="23544:23578" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="16696:16730" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="18737:18771" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="19206:19240" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="22212:22228" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="23022:23038" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="23734:23750" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="24383:24399" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="25038:25054" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="25683:25699" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="26191:26207" placeholder="..." />
+                <marker date="1446232656554" expanded="true" signature="26632:26648" placeholder="..." />
               </folding>
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="_index.html" pinned="false" current-in-tab="true">
+      <file leaf-file-name="_layers.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_layers.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.0">
+              <caret line="193" column="0" selection-start-line="193" selection-start-column="0" selection-end-line="193" selection-end-column="0" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="_index.html" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/app/templates/_index.html">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.25433525">
-              <caret line="55" column="0" selection-start-line="55" selection-start-column="0" selection-end-line="55" selection-end-column="0" />
+            <state vertical-scroll-proportion="0.0">
+              <caret line="119" column="40" selection-start-line="119" selection-start-column="40" selection-end-line="119" selection-end-column="40" />
               <folding>
                 <element signature="n#style#0;n#span#0;n#a#0;n#div#0;n#div#0;n#div#0;n#body#0;n#html#0;n#!!top" expanded="true" />
                 <element signature="n#style#0;n#div#1;n#body#0;n#html#0;n#!!top" expanded="true" />
@@ -76,11 +76,11 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="_main.css" pinned="false" current-in-tab="false">
+      <file leaf-file-name="_main.css" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/app/templates/_main.css">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="249" column="39" selection-start-line="249" selection-start-column="39" selection-end-line="249" selection-end-column="39" />
+            <state vertical-scroll-proportion="0.4271739">
+              <caret line="308" column="0" selection-start-line="308" selection-start-column="0" selection-end-line="308" selection-end-column="0" />
               <folding />
             </state>
           </provider>
@@ -101,11 +101,11 @@
         <option value="$PROJECT_DIR$/app/templates/gulpfile.js" />
         <option value="$PROJECT_DIR$/app/templates/_bower.json" />
         <option value="$PROJECT_DIR$/app/index.js" />
-        <option value="$PROJECT_DIR$/app/templates/map-esri/_layers.js" />
         <option value="$PROJECT_DIR$/app/templates/map-esri/_utilities.js" />
+        <option value="$PROJECT_DIR$/app/templates/_index.html" />
+        <option value="$PROJECT_DIR$/app/templates/map-esri/_layers.js" />
         <option value="$PROJECT_DIR$/app/templates/map-esri/_core.js" />
         <option value="$PROJECT_DIR$/app/templates/_main.css" />
-        <option value="$PROJECT_DIR$/app/templates/_index.html" />
       </list>
     </option>
   </component>
@@ -145,7 +145,7 @@
       <sortByType />
     </navigator>
     <panes>
-      <pane id="Scope" />
+      <pane id="Scratches" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -214,7 +214,7 @@
               <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
             </PATH_ELEMENT>
             <PATH_ELEMENT>
-              <option name="myItemId" value="map-leaflet" />
+              <option name="myItemId" value="map-esri" />
               <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
             </PATH_ELEMENT>
           </PATH>
@@ -242,7 +242,7 @@
           </PATH>
         </subPane>
       </pane>
-      <pane id="Scratches" />
+      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -621,13 +621,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/app/templates/map-leaflet/_layers.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.38836968">
-          <caret line="22" column="23" selection-start-line="22" selection-start-column="23" selection-end-line="22" selection-end-column="23" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/app/templates/gitignore">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.035306334">
@@ -677,13 +670,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_layers.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="165" column="30" selection-start-line="165" selection-start-column="30" selection-end-line="165" selection-end-column="30" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_utilities.js">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.25757575">
@@ -695,41 +681,14 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.72121215">
           <caret line="56" column="19" selection-start-line="56" selection-start-column="19" selection-end-line="56" selection-end-column="19" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_core.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="320" column="11" selection-start-line="320" selection-start-column="11" selection-end-line="320" selection-end-column="11" />
-          <folding>
-            <marker date="1446068830007" expanded="true" signature="16644:16678" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="18685:18719" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="19154:19188" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="22019:22035" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="22140:22174" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="22592:22608" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="22706:22740" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="23065:23081" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="23186:23220" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="23430:23446" placeholder="..." />
-            <marker date="1446068830007" expanded="true" signature="23544:23578" placeholder="..." />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/app/templates/_main.css">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="249" column="39" selection-start-line="249" selection-start-column="39" selection-end-line="249" selection-end-column="39" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/app/templates/_index.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.25433525">
-          <caret line="55" column="0" selection-start-line="55" selection-start-column="0" selection-end-line="55" selection-end-column="0" />
+        <state vertical-scroll-proportion="0.0">
+          <caret line="119" column="40" selection-start-line="119" selection-start-column="40" selection-end-line="119" selection-end-column="40" />
           <folding>
             <element signature="n#style#0;n#span#0;n#a#0;n#div#0;n#div#0;n#div#0;n#body#0;n#html#0;n#!!top" expanded="true" />
             <element signature="n#style#0;n#div#1;n#body#0;n#html#0;n#!!top" expanded="true" />
@@ -739,6 +698,50 @@
             <element signature="n#style#0;n#div#0;n#div#1;n#div#1;n#div#0;n#div#0;n#div#3;n#body#0;n#html#0;n#!!top" expanded="true" />
             <element signature="n#style#0;n#a#0;n#h4#0;n#div#0;n#div#0;n#div#0;n#div#1;n#div#0;n#div#3;n#body#0;n#html#0;n#!!top" expanded="true" />
           </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/templates/map-leaflet/_layers.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.38913044">
+          <caret line="22" column="23" selection-start-line="22" selection-start-column="23" selection-end-line="22" selection-end-column="23" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_layers.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="193" column="0" selection-start-line="193" selection-start-column="0" selection-end-line="193" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/templates/map-esri/_core.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="799" column="35" selection-start-line="799" selection-start-column="35" selection-end-line="799" selection-end-column="35" />
+          <folding>
+            <marker date="1446232656554" expanded="true" signature="16696:16730" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="18737:18771" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="19206:19240" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="22212:22228" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="23022:23038" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="23734:23750" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="24383:24399" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="25038:25054" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="25683:25699" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="26191:26207" placeholder="..." />
+            <marker date="1446232656554" expanded="true" signature="26632:26648" placeholder="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/templates/_main.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.4271739">
+          <caret line="308" column="0" selection-start-line="308" selection-start-column="0" selection-end-line="308" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>

--- a/app/templates/_main.css
+++ b/app/templates/_main.css
@@ -142,6 +142,12 @@ body {
     display:inline-block;
 }
 
+.lyrTogDiv {
+    width: 100%;
+    padding: 1px;
+    font-weight: bold;
+}
+
 .alert {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -200,6 +206,27 @@ body {
     width: 100%;
 }
 
+.lgi-zoom {
+    color: white;
+    background-color: black;
+    border: none !important;
+    padding: 5px 5px !important;
+}
+
+a.lgi-zoom {
+    color: white;
+}
+
+a.lgi-zoom:hover {
+    color: black;
+}
+
+.lyrTog {
+    width: 100%;
+    padding: 1px;
+    font-weight: bold;
+}
+
 .map {
     overflow: auto;
 }
@@ -207,6 +234,10 @@ body {
 #mapDiv {
     min-height: 100%;
     max-height: 100%;
+}
+
+.opacity {
+    padding-left: 10px;
 }
 
 .opacitySlider {
@@ -219,8 +250,6 @@ body {
     border: solid 1px white;
     background-color: black;
     z-index: 1000;
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
 }
 
@@ -275,7 +304,6 @@ body {
 
 #wim_logo:hover{
     background: blue none repeat scroll 0 0;
-    opacity: 0.8;
     cursor: pointer;
 }
 
@@ -291,9 +319,19 @@ input[type="checkbox"], input[type="radio"] {
     float: left;
 }
 
+.zoomDialog {
+    position: absolute;
+    color: white;
+    /*width: 200px;*/
+    padding: 5px;
+    /*padding-bottom: 40px;*/
+    opacity: 0.9;
+    border: solid 1px white;
+    background-color: black;
+    z-index: 1000;
+    border-radius: 5px;
+}
 
-.lyrTog {
-    width: 100%;
-    padding: 1px;
-    font-weight: bold;
+.zoomClose {
+    color: white;
 }

--- a/app/templates/map-esri/_core.js
+++ b/app/templates/map-esri/_core.js
@@ -11,7 +11,8 @@ var allLayers;
 var maxLegendHeight;
 var maxLegendDivHeight;
 var dragInfoWindows = true;
-        
+var defaultMapCenter = [-95.6, 38.6];
+
 require([
     'esri/arcgis/utils',
     'esri/map',
@@ -54,7 +55,8 @@ require([
 
     map = Map('mapDiv', {
         basemap: 'national-geographic',
-        center: [-95.6, 38.6],
+        //center: [-95.6, 38.6],
+        center: defaultMapCenter,
         zoom: 5
     });
     //button for returning to initial extent
@@ -96,13 +98,13 @@ require([
             var dnd = new Moveable(map.infoWindow.domNode, {
                 handle: handle
             });
-            
+
             // when the infoWindow is moved, hide the arrow:
             on(dnd, 'FirstMove', function() {
                 // hide pointer and outerpointer (used depending on where the pointer is shown)
                 var arrowNode =  query(".outerPointer", map.infoWindow.domNode)[0];
                 domClass.add(arrowNode, "hidden");
-                
+
                 var arrowNode =  query(".pointer", map.infoWindow.domNode)[0];
                 domClass.add(arrowNode, "hidden");
             }.bind(this));
@@ -179,10 +181,10 @@ require([
         var feature = graphic;
 
         var template = new esri.InfoTemplate("test popup",
-                        "attributes and stuff go here");
-                        
-        //ties the above defined InfoTemplate to the feature result returned from a click event 
-        
+            "attributes and stuff go here");
+
+        //ties the above defined InfoTemplate to the feature result returned from a click event
+
         feature.setInfoTemplate(template);
 
         map.infoWindow.setFeatures([feature]);
@@ -354,6 +356,7 @@ require([
         'esri/geometry/Extent',
         'esri/layers/ArcGISDynamicMapServiceLayer',
         'esri/layers/FeatureLayer',
+        'esri/SpatialReference',
         'esri/layers/WMSLayer',
         'esri/layers/WMSLayerInfo',
         'dijit/form/CheckBox',
@@ -374,6 +377,7 @@ require([
         Extent,
         ArcGISDynamicMapServiceLayer,
         FeatureLayer,
+        SpatialReference,
         WMSLayer,
         WMSLayerInfo,
         CheckBox,
@@ -540,14 +544,30 @@ require([
 
                 //create layer toggle
                 //var button = $('<div align="left" style="cursor: pointer;padding:5px;"><span class="glyphspan glyphicon glyphicon-check"></span>&nbsp;&nbsp;' + layerName + '</div>');
-                if (layer.visible && wimOptions.hasOpacitySlider !== undefined && wimOptions.hasOpacitySlider == true) {
-                    var button = $('<div class="btn-group-vertical lyrTog" style="cursor: pointer;" data-toggle="buttons"> <button type="button" class="btn btn-default active" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-check-square-o"></i>&nbsp;&nbsp;' + layerName + '<span id="opacity' + camelize(layerName) + '" class="glyphspan glyphicon glyphicon-adjust pull-right"></button></span></div>');
-                } else if ((!layer.visible && wimOptions.hasOpacitySlider !== undefined && wimOptions.hasOpacitySlider == true)) {
-                    var button = $('<div class="btn-group-vertical lyrTog" style="cursor: pointer;" data-toggle="buttons"> <button type="button" class="btn btn-default" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-square-o"></i>&nbsp;&nbsp;' + layerName + '<span id="opacity' + camelize(layerName) + '" class="glyphspan glyphicon glyphicon-adjust pull-right"></button></span></div>');
-                } else if (layer.visible) {
-                    var button = $('<div class="btn-group-vertical lyrTog" style="cursor: pointer;" data-toggle="buttons"> <button type="button" class="btn btn-default active" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-check-square-o"></i>&nbsp;&nbsp;' + layerName + '</button></span></div>');
+                if (layer.visible && wimOptions.hasOpacitySlider !== undefined && wimOptions.hasOpacitySlider == true && wimOptions.hasZoomto !== undefined && wimOptions.hasZoomto == true) {
+                    //opacity icon and zoomto icon; button selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default active" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-check-square-o"></i>&nbsp;&nbsp;' + layerName + '<span id="opacity' + camelize(layerName) + '" class="glyphspan glyphicon glyphicon-adjust pull-right opacity"></span><span class="glyphicon glyphicon-search pull-right zoomto"></span></button></div>');
+                } else if (!layer.visible && wimOptions.hasOpacitySlider !== undefined && wimOptions.hasOpacitySlider == true && wimOptions.hasZoomto !== undefined && wimOptions.hasZoomto == true){
+                    //opacity icon and zoomto icon; button not selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-square-o"></i>&nbsp;&nbsp;' + layerName + '<span id="opacity' + camelize(layerName) + '" class="glyphspan glyphicon glyphicon-adjust pull-right opacity"></span><span class="glyphicon glyphicon-search pull-right zoomto"></span></button></div>');
+                } else if (layer.visible && wimOptions.hasOpacitySlider !== undefined && wimOptions.hasOpacitySlider == true) {
+                    //opacity icon only; button selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default active" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-check-square-o"></i>&nbsp;&nbsp;' + layerName + '<span id="opacity' + camelize(layerName) + '" class="glyphspan glyphicon glyphicon-adjust pull-right"></button></div>');
+                } else if (!layer.visible && wimOptions.hasOpacitySlider !== undefined && wimOptions.hasOpacitySlider == true) {
+                    //opacity icon only; button not selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-square-o"></i>&nbsp;&nbsp;' + layerName + '<span id="opacity' + camelize(layerName) + '" class="glyphspan glyphicon glyphicon-adjust pull-right"></button></div>');
+                } else if (layer.visible && wimOptions.hasOpacitySlider == false && wimOptions.hasZoomto !== undefined && wimOptions.hasZoomto == true){
+                    //zoomto icon only; button selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default active" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-check-square-o"></i>&nbsp;&nbsp;' + layerName + '<span class="glyphicon glyphicon-search pull-right zoomto"></span></button></span></div>');
+                } else if (!layer.visible && wimOptions.hasOpacitySlider == false && wimOptions.hasZoomto !== undefined && wimOptions.hasZoomto == true) {
+                    //zoomto icon only; button not selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-square-o"></i>&nbsp;&nbsp;' + layerName + '<span class="glyphicon glyphicon-search pull-right zoomto"></span></button></span></div>');
+                } else if(layer.visible) {
+                    //no icons; button selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default active" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-check-square-o"></i>&nbsp;&nbsp;' + layerName + '</button></span></div>');
                 } else {
-                    var button = $('<div class="btn-group-vertical lyrTog" style="cursor: pointer;" data-toggle="buttons"> <button type="button" class="btn btn-default" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-square-o"></i>&nbsp;&nbsp;' + layerName + '</button> </div>');
+                    //no icons; button not selected
+                    var button = $('<div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons"> <button id="' + layer.id + '"type="button" class="btn btn-default" aria-pressed="true" style="font-weight: bold;text-align: left"><i class="glyphspan fa fa-square-o"></i>&nbsp;&nbsp;' + layerName + '</button> </div>');
                 }
 
                 //click listener for regular
@@ -593,6 +613,7 @@ require([
                     $('#' + groupDivID).append(exGroupDiv);
                 } else {
                     $('#' + groupDivID).append(button);
+                    //begin opacity slider logic
                     if ($("#opacity"+camelize(layerName)).length > 0) {
                         $("#opacity"+camelize(layerName)).hover(function () {
                             $(".opacitySlider").remove();
@@ -623,6 +644,51 @@ require([
                             });
                         });
                     }
+                    //end opacity slider logic
+
+                    //begin zoomto logic (in progress)
+                    $(".zoomto").hover(function (e) {
+
+                        $(".zoomDialog").remove();
+                        var layerToChange = this.parentNode.id;
+                        var zoomDialog = $('<div class="zoomDialog"><label class="zoomClose pull-right">X</label><br><div class="list-group"><a href="#" id="zoomscale" class="list-group-item lgi-zoom zoomscale">Zoom to scale</a> <a id="zoomcenter" href="#" class="list-group-item lgi-zoom zoomcenter">Zoom to center</a><a id="zoomextent" href="#" class="list-group-item lgi-zoom zoomextent">Zoom to extent</a></div></div>');
+
+                        $("body").append(zoomDialog);
+
+                        $(".zoomDialog").css('left', event.clientX-80);
+                        $(".zoomDialog").css('top', event.clientY-5);
+
+                        $(".zoomDialog").mouseleave(function() {
+                            $(".zoomDialog").remove();
+                        });
+
+                        $(".zoomClose").click(function() {
+                            $(".zoomDialog").remove();
+                        });
+
+                        $('#zoomscale').click(function (e) {
+                            //logic to zoom to layer scale
+                            var layerMinScale = map.getLayer(layerToChange).minScale;
+                            map.setScale(layerMinScale);
+                        });
+
+                        $("#zoomcenter").click(function (e){
+                            //logic to zoom to layer center
+                            //var layerCenter = map.getLayer(layerToChange).fullExtent.getCenter();
+                            //map.centerAt(layerCenter);
+                            var dataCenter = new Point(defaultMapCenter, new SpatialReference({wkid:4326}));
+                            map.centerAt(dataCenter);
+
+                        });
+
+                        $("#zoomextent").click(function (e){
+                            //logic to zoom to layer extent
+                            var layerExtent = map.getLayer(layerToChange).fullExtent;
+                            map.setExtent(layerExtent);
+                        });
+                    });
+                    //end zoomto logic
+
                 }
             }
 

--- a/app/templates/map-esri/_layers.js
+++ b/app/templates/map-esri/_layers.js
@@ -89,19 +89,6 @@ require([
             "showGroupHeading": true,
             "includeInLayerList": true,
             "layers": {
-                "Pt Feature Layer": {
-                    "url" : "http://wim.usgs.gov/arcgis/rest/services/BadRiverDataPortal/NWIS_Sites/MapServer/0",
-                    "options": {
-                        "id": "ptFeatureLayer",
-                        "visible": true
-                    },
-                    "wimOptions": {
-                        "type": "layer",
-                        "layerType": "agisFeature",
-                        "includeInLayerList": true,
-                        "includeLegend" : false
-                    }
-                },
                 "FIM Sites": {
                     "url" : "http://fim.wimcloud.usgs.gov/arcgis/rest/services/FIMMapper/sites/MapServer/0",
                     "options": {
@@ -114,6 +101,7 @@ require([
                         "layerType": "agisFeature",
                         "includeInLayerList": true,
                         "hasOpacitySlider": true,
+                        "hasZoomto": true,
                         "includeLegend" : true
                     }
                 }
@@ -168,6 +156,7 @@ require([
                     "options": {
                         "id": "Wetlands",
                         "opacity": 0.75,
+                        "minScale": 144448,
                         "visible": true
                     },
                     "wimOptions": {
@@ -176,6 +165,7 @@ require([
                         "includeInLayerList": true,
                         "zoomScale": 144448,
                         "hasOpacitySlider": true,
+                        "hasZoomto" : true,
                         "includeLegend" : true
                     }
                 },
@@ -192,6 +182,7 @@ require([
                         "layerType": "agisDynamic",
                         "includeInLayerList": true,
                         "hasOpacitySlider": true,
+                        "hasZoomto": true,
                         "includeLegend" : false
                     }
                 }


### PR DESCRIPTION
zoom-to "widget" ported over from my work on WLERA. It has 3 buttons: zoom to scale, zoom to center, and zoom to scale. The zoom to center was added per cooperator request for WLERA - it returns the user to map center. Could either drop it entirely, or update it to bring user to layer center. Layer center was the original intent, but they had a weird shaped dataset that made layer center less than useful.

Please run a yo wim and check this out for bugs when you can. 
